### PR TITLE
Refactor popover positioning service

### DIFF
--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -21,7 +21,7 @@ const positionComplements = {
 
 // always resolving to top/left is taken advantage of by knowing they are the
 // minimum edges of the bounding box
-const positionSubstitues = {
+const positionSubstitutes = {
   top: 'left',
   right: 'top',
   bottom: 'left',
@@ -121,7 +121,7 @@ export function findPopoverPosition({ anchor, popover, position, buffer=16, offs
       // iteration 1 is the complement of the requested position,
       // the desired axis doesn't have room, try the opposite one
       // e.g. "top" -> "left" or "right" -> "top"
-      iterationPosition = positionSubstitues[iterationPosition];
+      iterationPosition = positionSubstitutes[iterationPosition];
     }
   }
 
@@ -178,7 +178,7 @@ export function getPopoverScreenCoordinates({ position, anchorBoundingBox, popov
    *
    */
 
-  const crossAxisFirstSide = positionSubstitues[position]; // "top" -> "left"
+  const crossAxisFirstSide = positionSubstitutes[position]; // "top" -> "left"
   const crossAxisSecondSide = positionComplements[crossAxisFirstSide]; // "left" -> "right"
   const crossAxisDimension = relatedDimension[crossAxisFirstSide]; // "left" -> "width"
 

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -211,7 +211,6 @@ export function getPopoverScreenCoordinates({
     containerBoundingBox,
     popoverBoundingBox,
     anchorBoundingBox,
-    minimumSpace: arrowConfig ? arrowConfig.arrowBuffer : 0,
     arrowConfig,
   });
 
@@ -274,7 +273,6 @@ function getCrossAxisPosition({
   popoverBoundingBox,
   anchorBoundingBox,
   arrowConfig,
-  minimumSpace = 0,
 }) {
   // how much of the popover overflows past either side of the anchor if its centered
   const popoverSizeOnCrossAxis = popoverBoundingBox[crossAxisDimension];
@@ -291,6 +289,7 @@ function getCrossAxisPosition({
   // compute the smaller of the two spaces along each edge
   const combinedBoundingBox = intersectBoundingBoxes(windowBoundingBox, containerBoundingBox);
   const availableSpace = getAvailableSpace(anchorBoundingBox, combinedBoundingBox, buffer, offset, position);
+  const minimumSpace = arrowConfig ? arrowConfig.arrowBuffer : 0;
   availableSpace[crossAxisFirstSide] = Math.max(availableSpace[crossAxisFirstSide], minimumSpace);
   availableSpace[crossAxisSecondSide] = Math.max(availableSpace[crossAxisSecondSide], minimumSpace);
 

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -139,14 +139,27 @@ export function findPopoverPosition({ anchor, popover, position, buffer=16, offs
  * @param popoverBoundingBox {Object} bounding box of the popover element
  * @param windowBoundingBox {Object} bounding box of the window
  * @param containerBoundingBox {Object} bounding box of the container
- * @param [arrowConfig] {{arrowWidth: number, arrowBuffer: number}} If present, describes the size & constraints for an arrow element, and the function return value will include an `arrow` param with position details
+ * @param [arrowConfig] {{arrowWidth: number, arrowBuffer: number}} If present, describes the size &
+ *  constraints for an arrow element, and the function return value will include an `arrow` param
+ *  with position details
  * @param [offset=0] {number} Distance between the popover and the anchor
  * @param [buffer=0] {number} Minimum distance between the popover's placement and the container edge
  *
- * @returns {{top: number, left: number, relativePlacement: string, fit: number, arrow?: {top: number, left: number}}|null} object with top/left coordinates, the popover's relative position to the anchor, and how well the popover fits in the location (0.0 -> 1.0)
- * coordinates and the popover's relative position, if there is no room in this placement then null
+ * @returns {{top: number, left: number, relativePlacement: string, fit: number, arrow?: {top: number, left: number}}|null}
+ *  object with top/left coordinates, the popover's relative position to the anchor, and how well the
+ *  popover fits in the location (0.0 -> 1.0) oordinates and the popover's relative position, if
+ *  there is no room in this placement then null
  */
-export function getPopoverScreenCoordinates({ position, anchorBoundingBox, popoverBoundingBox, windowBoundingBox, containerBoundingBox, arrowConfig, offset=0, buffer=0 }) {
+export function getPopoverScreenCoordinates({
+  position,
+  anchorBoundingBox,
+  popoverBoundingBox,
+  windowBoundingBox,
+  containerBoundingBox,
+  arrowConfig,
+  offset=0,
+  buffer=0,
+}) {
   /**
    * The goal is to find the best way to align the popover content
    * on the given side of the anchor element. The popover prefers


### PR DESCRIPTION
I broke this PR into the following steps, with corresponding commits:

1) I grouped related variables in `getPopoverScreenCoordinates` into discrete steps:
  a) Find original cross-axis position.
  b) Apply shift to cross-axis position, if necessary.
  c) Find primary axis position.
2) I extracted these steps into `getCrossAxisPosition` and `getPrimaryAxisPosition` helper functions, which also encapsulate the arrow-positioning logic for each axis. The primary axis arrow positioning logic was both adding and subtracting `positioning[primaryAxisPositionName]`, so I removed those operations.
3) I defined an `iterationPositions` array in `getPopoverScreenCoordinates`, which we traverse to get the best-fitting position, instead of defining the next iteration position in each loop. I found it easier to understand the strategy this way.